### PR TITLE
Fix: fibRoute.ts Lint & Test Lint & Test

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -2,7 +2,7 @@
 
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: { params: { num: string } }, res: { send: (arg0: string) => void }) => {
   const { num } = req.params;
 
   const fibN: number = fibonacci(parseInt(num));


### PR DESCRIPTION
For some reason, I still got errors even though the Jest test suite did not show any in my command prompt. To fix the issues reported by the Lint & Test workflow run, I provided explicit types for the req and res parameters in the function signature.